### PR TITLE
Rewrite internal tests to use hunit and lens, not hspec.

### DIFF
--- a/couch-simple.cabal
+++ b/couch-simple.cabal
@@ -49,8 +49,9 @@ test-suite test
                , hspec
                , http-client
                , http-types
+               , lens < 4.4
                , tasty
-               , tasty-hspec >= 0.1.0.1 && < 0.2
+               , tasty-hunit
                , unordered-containers
   default-language: Haskell2010
   ghc-options: -Wall

--- a/test/test.hs
+++ b/test/test.hs
@@ -5,6 +5,5 @@ import Couch.Internal
 
 main :: IO ()
 main = do
-  internalTests <- getInternalTests
   let allTests = testGroup "All tests" [internalTests]
   defaultMain allTests


### PR DESCRIPTION
While hspec might be the better option long-term, the version we have in
Debian right now is too old to do what I need.

Moving to lens is just for my own sanity.  Of course, because of my dev
environment, and cabal's limitations, I have to stick with lens < 4.4
for the moment.
