### PR TITLE
Fix initial doc queries.

### DIFF
--- a/src/lib/Database/Couch/ResponseParser.hs
+++ b/src/lib/Database/Couch/ResponseParser.hs
@@ -83,6 +83,7 @@ checkStatusCode = do
     200 -> return ()
     201 -> return ()
     202 -> return ()
+    304 -> return ()
     400 -> do
       error <- getKey "reason" >>= toOutputType
       failed $ InvalidName error


### PR DESCRIPTION
First off, they weren't handling the `Maybe DocRev` correctly.  And then
once that was solved, they needed to be able to handle 304 return
values, which needed a change in `checkStatusCode`, as well as checks to
return an appropriate value (in this case, `Null`, since that's
otherwise _not_ a legit document).
