### PR TITLE
Fix excessively constrained createDoc.

### DIFF
--- a/src/lib/Database/Couch/Explicit/Database.hs
+++ b/src/lib/Database/Couch/Explicit/Database.hs
@@ -133,7 +133,7 @@ delete =
 -- 'DocRev' in that circumstance.
 --
 -- Status: __Complete__
-createDoc :: (FromJSON a, MonadIO m, ToJSON a) => Bool -> a -> Context -> m (Either CouchError (a, Maybe CookieJar))
+createDoc :: (FromJSON a, MonadIO m, ToJSON b) => Bool -> b -> Context -> m (Either CouchError (a, Maybe CookieJar))
 createDoc batch doc =
   standardRequest request
   where

--- a/src/lib/Database/Couch/Types.hs
+++ b/src/lib/Database/Couch/Types.hs
@@ -32,6 +32,7 @@ import           Data.Bool               (Bool)
 import           Data.ByteString         (ByteString)
 import           Data.ByteString.Builder (intDec, toLazyByteString)
 import           Data.ByteString.Lazy    (toStrict)
+import           Data.Either             (Either)
 import           Data.Eq                 (Eq)
 import           Data.Function           (($), (.))
 import           Data.Functor            (fmap)
@@ -176,6 +177,8 @@ data Credentials
     credUser :: User,
     credPass :: Password
     }
+
+type CouchResult a = Either CouchError (a, Maybe CookieJar)
 
 -- | Result type for creating a new document in a database.
 data CreateResult

--- a/test/Functionality/Explicit/Configuration.hs
+++ b/test/Functionality/Explicit/Configuration.hs
@@ -6,15 +6,13 @@ module Functionality.Explicit.Configuration where
 
 import           Control.Applicative                   ((<$>))
 import           Data.Aeson                            (Value (String))
-import           Data.Either                           (Either)
 import           Data.Function                         (($))
-import           Data.Maybe                            (Maybe)
 import qualified Database.Couch.Explicit.Configuration as Configuration (delValue, getValue, section,
                                                                          server, setValue)
-import           Database.Couch.Types                  (Context, CouchError)
+import           Database.Couch.Types                  (Context, CouchResult)
 import           Functionality.Util                    (runTests, serverContext,
                                                         testAgainstSchema)
-import           Network.HTTP.Client                   (CookieJar, Manager)
+import           Network.HTTP.Client                   (Manager)
 import           System.IO                             (IO)
 import           Test.Tasty                            (TestTree, testGroup)
 
@@ -42,5 +40,5 @@ setValue = testAgainstSchema "Set config item" (Configuration.setValue "testsect
 
 delValue :: IO Context -> TestTree
 delValue = testAgainstSchema "Delete config item" (\c -> do
-                                                       _ :: Either CouchError (Value, Maybe CookieJar) <- Configuration.setValue "testsection" "testkey" (String "foo") c
+                                                       _ :: CouchResult Value <- Configuration.setValue "testsection" "testkey" (String "foo") c
                                                        Configuration.delValue "testsection" "testkey" c) "delete--_config-section-key.json"

--- a/test/Functionality/Explicit/Database.hs
+++ b/test/Functionality/Explicit/Database.hs
@@ -5,7 +5,7 @@
 module Functionality.Explicit.Database where
 
 import           Control.Applicative              ((<$>))
-import           Control.Monad                    (void, (>>))
+import           Control.Monad                    ((>>))
 import           Data.Aeson                       (Object, Value (Bool, Number),
                                                    object)
 import           Data.Bool                        (Bool (False, True))
@@ -32,7 +32,7 @@ import qualified Database.Couch.Explicit.Database as Database (allDocs,
 import qualified Database.Couch.Response          as Response (asAnything,
                                                                asBool)
 import           Database.Couch.Types             (Context (ctxDb),
-                                                   CouchError (..),
+                                                   CouchError (..), CouchResult,
                                                    DocId (DocId),
                                                    DocRev (DocRev),
                                                    DocRevMap (DocRevMap),
@@ -145,7 +145,7 @@ databaseCreateDoc =
     , withDb $ testAgainstFailure
                  "Try to create a document twice"
                  (\c -> do
-                    void $ Database.createDoc False (object [("_id", "foo"), ("llamas", Bool True)]) c
+                    _ :: CouchResult Value <- Database.createDoc False (object [("_id", "foo"), ("llamas", Bool True)]) c
                     Database.createDoc False (object [("_id", "foo"), ("llamas", Bool True)]) c)
                  Conflict
     ]
@@ -158,7 +158,7 @@ databaseAllDocs =
     , withDb $ testAgainstSchema
                  "Add a record and get all docs"
                  (\c -> do
-                    void $ Database.createDoc False (object [("_id", "foo"), ("llamas", Bool True)]) c
+                    _ :: CouchResult Value <- Database.createDoc False (object [("_id", "foo"), ("llamas", Bool True)]) c
                     Database.allDocs dbAllDocs c)
                  "get--db-_all_docs.json"
     ]
@@ -171,8 +171,8 @@ databaseSomeDocs =
       lookup "total_rows" val @=? Just (Number 0), withDb $ testAgainstSchemaAndValue
                                                               "Add a record and get all docs"
                                                               (\c -> do
-                                                                 void $ Database.createDoc False (object [("_id", "foo"), ("llamas", Bool True)]) c
-                                                                 void $ Database.createDoc False (object [("_id", "bar"), ("llamas", Bool True)]) c
+                                                                 _ :: CouchResult Value <- Database.createDoc False (object [("_id", "foo"), ("llamas", Bool True)]) c
+                                                                 _ :: CouchResult Value <- Database.createDoc False (object [("_id", "bar"), ("llamas", Bool True)]) c
                                                                  Database.someDocs ["foo"] c)
                                                               "get--db-_all_docs.json"
                                                               Response.asAnything $ \step (val :: Object) -> do
@@ -233,7 +233,7 @@ databaseTempView :: IO Context -> TestTree
 databaseTempView =
   makeTests "Database temporary view"
   [ withDb $ testAgainstSchema "Random database" (\c -> do
-                                                      void $ Database.createDoc False (object [("_id", "foo"), ("llamas", Bool True)]) c
+                                                      _ :: CouchResult Value <- Database.createDoc False (object [("_id", "foo"), ("llamas", Bool True)]) c
                                                       Database.tempView "function (doc) { emit (1); }" (Just "_count") c) "post--db-_temp_view.json"
   ]
 

--- a/test/Functionality/Explicit/Doc.hs
+++ b/test/Functionality/Explicit/Doc.hs
@@ -4,7 +4,6 @@
 
 module Functionality.Explicit.Doc where
 
-import           Control.Monad                    (void)
 import           Data.Aeson                       (Value (Bool), object)
 import           Data.Bool                        (Bool (False, True))
 import           Data.Function                    (($))
@@ -12,7 +11,7 @@ import           Data.Maybe                       (Maybe (Nothing))
 import qualified Database.Couch.Explicit.Database as Database (createDoc)
 import qualified Database.Couch.Explicit.Doc      as Doc (get, size)
 import           Database.Couch.Types             (Context, CouchError (..),
-                                                   docGetDoc)
+                                                   CouchResult, docGetDoc)
 import           Functionality.Util               (makeTests, runTests,
                                                    testAgainstFailure,
                                                    testAgainstSchema, withDb)
@@ -37,7 +36,7 @@ docSize =
     , withDb $ testAgainstSchema
                  "Add a record and get all docs"
                  (\c -> do
-                    void $ Database.createDoc False (object [("_id", "foo"), ("llamas", Bool True)]) c
+                    _ :: CouchResult Value <- Database.createDoc False (object [("_id", "foo"), ("llamas", Bool True)]) c
                     Doc.size docGetDoc "foo" Nothing c)
                  "head--db-docid.json"
     ]
@@ -49,7 +48,7 @@ docGet =
     , withDb $ testAgainstSchema
                  "Add a doc and get the docs"
                  (\c -> do
-                    void $ Database.createDoc False (object [("_id", "foo"), ("llamas", Bool True)]) c
+                    _ :: CouchResult Value <- Database.createDoc False (object [("_id", "foo"), ("llamas", Bool True)]) c
                     Doc.get docGetDoc "foo" Nothing c)
                  "get--db-docid.json"
     ]


### PR DESCRIPTION
The input and output types of this function were being inappropriately
tied together.  Oops.  Once I fixed that constraint, though, a lot of
code could no longer assert anything about the type of the return value,
so I could no longer just use `void` if I wasn't examining it.

Typing `Either CouchError (a, Maybe CookieJar)` was pretty darned
boring, though, so I created a type synonym, `CouchResult a`, to make
that a little more sensible.  I have so far only applied it in the
tests, though obviously it can be applied to the actual API functions,
too.
