### PR TITLE
Adapt to hjsonschema >= 0.7.

### DIFF
--- a/couch-simple.cabal
+++ b/couch-simple.cabal
@@ -66,7 +66,7 @@ test-suite test
                , directory
                , exceptions
                , filepath
-               , hjsonschema >= 0.6
+               , hjsonschema >= 0.7 && < 0.8
                , hlint == 1.*
                , http-client >= 0.4.18
                , http-types

--- a/test/Functionality/Util.hs
+++ b/test/Functionality/Util.hs
@@ -19,7 +19,7 @@ import           Data.JsonSchema                  (RawSchema (..), compile,
 import           Data.Maybe                       (Maybe (Just, Nothing))
 import           Data.Monoid                      (mempty, (<>))
 import           Data.String                      (IsString, String, fromString,
-                                                   unwords)
+                                                   unlines, unwords)
 import           Data.UUID                        (toString)
 import qualified Database.Couch.Explicit.Database as Database (create, delete)
 import qualified Database.Couch.Response          as Response (asBool)
@@ -147,8 +147,8 @@ checkSchema step value schemaName = do
   step "Checking result against schema"
   schema <- loadSchema ("test/schema/schema" </> schemaName)
   case validate (compile draft4 mempty schema) value of
-    Left err -> assertFailure $ unwords ["Failed to validate", show value, ":", show err]
-    Right _  -> return ()
+    [] -> return ()
+    failures -> assertFailure $ unwords ["Failed to validate", show value, ":", unlines $ fmap show failures]
 
 loadSchema :: FilePath -> IO RawSchema
 loadSchema file = do


### PR DESCRIPTION
An API change in validate meant our tests failed to compile.
